### PR TITLE
fix: treat arrow functions in property declarations and assignments as non-anonymous

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "add-function-return-types",
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"description": "A CLI tool to add explicit return types to TypeScript functions",
 	"files": ["dist/"],
 	"main": "./dist/index.js",

--- a/src/addFunctionReturnTypes.ts
+++ b/src/addFunctionReturnTypes.ts
@@ -244,7 +244,8 @@ async function processFile(
 					// Check if arrow function is assigned to a variable or property declaration
 					if (
 						(!Node.isVariableDeclaration(parent) || !parent.getName()) &&
-						!Node.isPropertyDeclaration(parent)
+						!Node.isPropertyDeclaration(parent) &&
+						!Node.isPropertyAssignment(parent)
 					) {
 						return
 					}

--- a/src/addFunctionReturnTypes.ts
+++ b/src/addFunctionReturnTypes.ts
@@ -241,8 +241,11 @@ async function processFile(
 
 				if (Node.isArrowFunction(node)) {
 					const parent = node.getParent()
-					// Check if arrow function is assigned to a variable declaration
-					if (!Node.isVariableDeclaration(parent) || !parent.getName()) {
+					// Check if arrow function is assigned to a variable or property declaration
+					if (
+						(!Node.isVariableDeclaration(parent) || !parent.getName()) &&
+						!Node.isPropertyDeclaration(parent)
+					) {
 						return
 					}
 				}

--- a/src/addFunctionReturnTypes.ts
+++ b/src/addFunctionReturnTypes.ts
@@ -241,11 +241,16 @@ async function processFile(
 
 				if (Node.isArrowFunction(node)) {
 					const parent = node.getParent()
-					// Check if arrow function is assigned to a variable or property declaration
+					// Check if arrow function is assigned to a variable declaration, property declaration, or
+					// it is a property assignment
 					if (
 						(!Node.isVariableDeclaration(parent) || !parent.getName()) &&
 						!Node.isPropertyDeclaration(parent) &&
-						!Node.isPropertyAssignment(parent)
+						!Node.isPropertyAssignment(parent) &&
+						!(
+							Node.isBinaryExpression(parent) &&
+							parent.getOperatorToken().getKind() === SyntaxKind.EqualsToken
+						)
 					) {
 						return
 					}

--- a/test/addFunctionReturnTypes.test.ts
+++ b/test/addFunctionReturnTypes.test.ts
@@ -1124,7 +1124,17 @@ const object = {
     arrowObjectProp: () => {
         return 456;
     }
-}
+};
+
+const object2 = {};
+object2.arrowObject2Prop = () => {
+    return 456;
+};
+
+let variable;
+variable = () => {
+    return 456;
+};
 `.trim()
 
 		const testDir = await fs.mkdtemp(tmpDir)
@@ -1143,6 +1153,8 @@ const object = {
 		expect(updatedSource).toContain('const namedArrow = (): number => {')
 		expect(updatedSource).toContain('arrowClassProp = (): number => {')
 		expect(updatedSource).toContain('arrowObjectProp: (): number => {')
+		expect(updatedSource).toContain('arrowObject2Prop = (): number => {')
+		expect(updatedSource).toContain('variable = (): number => {')
 	})
 
 	it('handles anonymous functions if ignoreAnonymousFunctions is false', async (): Promise<void> => {
@@ -1173,7 +1185,17 @@ const object = {
     arrowObjectProp: () => {
         return 456;
     }
-}
+};
+
+const object2 = {};
+object2.arrowObject2Prop = () => {
+    return 456;
+};
+
+let variable;
+variable = () => {
+    return 456;
+};
 `.trim()
 
 		const testDir = await fs.mkdtemp(tmpDir)
@@ -1192,6 +1214,8 @@ const object = {
 		expect(updatedSource).toContain('const namedArrow = (): number => {')
 		expect(updatedSource).toContain('arrowClassProp = (): number => {')
 		expect(updatedSource).toContain('arrowObjectProp: (): number => {')
+		expect(updatedSource).toContain('arrowObject2Prop = (): number => {')
+		expect(updatedSource).toContain('variable = (): number => {')
 	})
 
 	it('ignores functions returning Promise<any> if ignoreAny is true', async (): Promise<void> => {

--- a/test/addFunctionReturnTypes.test.ts
+++ b/test/addFunctionReturnTypes.test.ts
@@ -1115,7 +1115,13 @@ const namedArrow = () => {
 }
 
 class Class {
-    arrowProp = () => {
+    arrowClassProp = () => {
+        return 456;
+    }
+}
+
+const object = {
+    arrowObjectProp: () => {
         return 456;
     }
 }
@@ -1135,7 +1141,8 @@ class Class {
 		expect(updatedSource).toContain('(() => {')
 		expect(updatedSource).toContain('function namedFunction(): boolean {')
 		expect(updatedSource).toContain('const namedArrow = (): number => {')
-		expect(updatedSource).toContain('arrowProp = (): number => {')
+		expect(updatedSource).toContain('arrowClassProp = (): number => {')
+		expect(updatedSource).toContain('arrowObjectProp: (): number => {')
 	})
 
 	it('handles anonymous functions if ignoreAnonymousFunctions is false', async (): Promise<void> => {
@@ -1155,6 +1162,18 @@ function namedFunction() {
 const namedArrow = () => {
     return 456;
 }
+
+class Class {
+    arrowClassProp = () => {
+        return 456;
+    }
+}
+
+const object = {
+    arrowObjectProp: () => {
+        return 456;
+    }
+}
 `.trim()
 
 		const testDir = await fs.mkdtemp(tmpDir)
@@ -1171,6 +1190,8 @@ const namedArrow = () => {
 		expect(updatedSource).toContain('((): string => {')
 		expect(updatedSource).toContain('function namedFunction(): boolean {')
 		expect(updatedSource).toContain('const namedArrow = (): number => {')
+		expect(updatedSource).toContain('arrowClassProp = (): number => {')
+		expect(updatedSource).toContain('arrowObjectProp: (): number => {')
 	})
 
 	it('ignores functions returning Promise<any> if ignoreAny is true', async (): Promise<void> => {

--- a/test/addFunctionReturnTypes.test.ts
+++ b/test/addFunctionReturnTypes.test.ts
@@ -882,7 +882,7 @@ const typedFunction: () => number = function() {
 	  (function() {
 		return 42;
 	  })();
-	  
+
 	  function normalFunction() {
 		return 43;
 	  }
@@ -1113,6 +1113,12 @@ function namedFunction() {
 const namedArrow = () => {
     return 456;
 }
+
+class Class {
+    arrowProp = () => {
+        return 456;
+    }
+}
 `.trim()
 
 		const testDir = await fs.mkdtemp(tmpDir)
@@ -1129,6 +1135,7 @@ const namedArrow = () => {
 		expect(updatedSource).toContain('(() => {')
 		expect(updatedSource).toContain('function namedFunction(): boolean {')
 		expect(updatedSource).toContain('const namedArrow = (): number => {')
+		expect(updatedSource).toContain('arrowProp = (): number => {')
 	})
 
 	it('handles anonymous functions if ignoreAnonymousFunctions is false', async (): Promise<void> => {


### PR DESCRIPTION
Hello. As I [said](https://www.reddit.com/r/typescript/comments/itxos7/comment/lvy2tcw/) in a comment on Reddit, this repo is a real treasure!

An hour ago, you've also implemented the exact feature I was about to request – ignoring anonymous functions.

There is a problem though: it correctly handles variable declarations but overlooks property declarations like this:
```ts
class Class {
    arrowClassProp = () => {
        return 456;
    }
}
```
and property assignments like this:
```ts
const object = {
    arrowObjectProp: () => {
        return 456;
    }
}
```

These are sometimes used to simplify adding and removing event listeners, because they automatically capture `this` and provide a stable reference to uninstall, e.g. see [Google style guide](https://google.github.io/styleguide/tsguide.html#event-handlers).

`--ignore-anonymous-functions` should not ignore them.

This PR solves this to the extent that I could figure out `ts-morph`'s API. I added tests as well.