### PR TITLE
fix: set package version to match latest npm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "add-function-return-types",
-	"version": "0.0.1",
+	"version": "3.6.1",
 	"description": "A CLI tool to add explicit return types to TypeScript functions",
 	"files": [
 		"dist/"


### PR DESCRIPTION
## Summary
- Set `package.json` version from `0.0.1` to `3.6.1` to match the latest published npm version
- The previous release workflow reset the version to `0.0.0`, causing the new workflow to bump to `0.0.1` which already exists on npm

## Test plan
- [ ] Merge and verify the release workflow publishes `3.6.2` (or appropriate bump) successfully